### PR TITLE
Use standard config locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,16 +48,20 @@ $(TOOR):
 $(PKG):
 	mkdir -p $(PKG)
 
+.PHONY: fetch
 fetch: $(CACHE)
 	cd $(CACHE); wget -N $(ZK_URL)
 
+.PHONY: extract
 extract: fetch $(TOOR)
 	mkdir -p "$(TOOR)"/opt/mesosphere/zookeeper
 	cd "$(TOOR)"/opt/mesosphere/zookeeper && tar xzf "$(CACHE)/$(SRC_TGZ)" --strip=1
 
+.PHONY: clean
 clean:
 	rm -rf tmp
 
+.PHONY: distclean
 distclean: clean
 	rm -rf $(PKG)
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ PKG_REL   := $(subst $(SPACE),.,$(strip $(ITEMS)))
 ZK_URL    ?= http://mirror.cogentco.com/pub/apache/zookeeper/stable/zookeeper-$(PKG_VER).tar.gz 
 SRC_TGZ    = $(notdir $(ZK_URL))
 CONTENTS  := opt/mesosphere/zookeeper/bin opt/mesosphere/zookeeper/lib \
-	opt/mesosphere/zookeeper/conf \
-	opt/mesosphere/zookeeper/zookeeper-$(PKG_VER).jar usr
+	opt/mesosphere/zookeeper/zookeeper-$(PKG_VER).jar usr etc
 
 TOP       := $(CURDIR)
 CACHE      = $(TOP)/tmp/cache
@@ -68,13 +67,15 @@ all: centos7
 .PHONY: centos7
 centos7: extract $(PKG)
 centos7: $(TOOR)/usr/lib/systemd/system/$(NAME).service
-centos7: $(TOOR)/opt/mesosphere/zookeeper/conf/zoo.cfg
+centos7: $(TOOR)/etc/zookeeper/conf/zoo.cfg
 	cd $(PKG) && fpm -C $(TOOR) \
-		--config-files opt/mesosphere/zookeeper/conf \
+		--config-files etc \
 		--after-install $(TOP)/postinst --iteration $(PKG_REL).centos7 \
 		$(FPM_OPTS) $(CONTENTS)
 
-$(TOOR)/opt/mesosphere/zookeeper/conf/zoo.cfg: zoo.cfg extract $(TOOR)
+$(TOOR)/etc/zookeeper/conf/zoo.cfg: zoo.cfg extract $(TOOR)
+	mkdir -p $(TOOR)/etc/zookeeper/conf
+	cp -rp $(TOOR)/opt/mesosphere/zookeeper/conf/* $(TOOR)/etc/zookeeper/conf/
 	cp zoo.cfg "$@"
 
 $(TOOR)/usr/lib/systemd/system/$(NAME).service: zookeeper.service

--- a/zoo.cfg
+++ b/zoo.cfg
@@ -23,6 +23,6 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-dataDir=/opt/mesosphere/zookeeper/var/lib/zookeeper
+dataDir=/var/lib/zookeeper
 # the port at which the clients will connect
 clientPort=2181

--- a/zookeeper.service
+++ b/zookeeper.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Apache ZooKeeper
 After=network.target
-ConditionPathExists=/opt/mesosphere/zookeeper/conf/zoo.cfg
-ConditionPathExists=/opt/mesosphere/zookeeper/conf/log4j.properties
+ConditionPathExists=/etc/zookeeper/conf/zoo.cfg
+ConditionPathExists=/etc/zookeeper/conf/log4j.properties
 
 [Service]
+Environment="ZOOCFGDIR=/etc/zookeeper/conf"
 SyslogIdentifier=mesosphere-zookeeper
 WorkingDirectory=/opt/mesosphere/zookeeper
 ExecStart=/opt/mesosphere/zookeeper/bin/zkServer.sh start-foreground


### PR DESCRIPTION
Use the standard config locations for zookeeper configuration
(`/etc/zookeeper/conf`) and state (`/var/lib/zookeeper`). This should make
it easier for users to work with our package. Since the package is
explicitly set to conflict with zookeeper and zookeeper-server, users
should be somewhat protected from having conflicting packages installed
at the same time.
